### PR TITLE
5.4 ラムダ式 文法修正

### DIFF
--- a/C++11-Syntax-and-Feature.xhtml
+++ b/C++11-Syntax-and-Feature.xhtml
@@ -4005,7 +4005,7 @@ int main()
 </p>
 
 <pre>
-[ ラムダキャプチャー<sub>opt</sub> ] ( 仮引数 ) mutable<sub>opt</sub> 例外指定<sub>opt</sub> -&gt; 戻り値の型<sub>opt</sub>
+[ ラムダキャプチャー<sub>opt</sub> ] ( 仮引数 )<sub>opt</sub> mutable<sub>opt</sub> 例外指定<sub>opt</sub> -&gt; 戻り値の型<sub>opt</sub> 複合文
 </pre>
 
 <article>


### PR DESCRIPTION
ちょっと自信ないですが、引数リスト部分は括弧を含めて省略可能で、複合文は必須なのでこのように修正しました。
