### PR TITLE
replace unevaluated_operand with unevaluated operand

### DIFF
--- a/C++11-Syntax-and-Feature.xhtml
+++ b/C++11-Syntax-and-Feature.xhtml
@@ -5559,10 +5559,10 @@ x = y = 0 ;
 </article>
 
 <article>
-<h1 id="unevaluated_operand"><a href="#unevaluated_operand">未評価オペランド（unevaluated_operand）</a></h1>
+<h1 id="unevaluated_operand"><a href="#unevaluated_operand">未評価オペランド（unevaluated operand）</a></h1>
 
 <p>
-<a href="#expr.typeid">typeid演算子</a>、<a href="#expr.sizeof">sizeof演算子</a>、<a href="#expr.unary.noexcept">noexcept演算子</a>、<a href="#dcl.type.simple">decltype型指定子</a>では、あるいは未評価オペランド（unevaluated_operand）というものが使われる。このオペランドは文字通り、評価されない式である。
+<a href="#expr.typeid">typeid演算子</a>、<a href="#expr.sizeof">sizeof演算子</a>、<a href="#expr.unary.noexcept">noexcept演算子</a>、<a href="#dcl.type.simple">decltype型指定子</a>では、あるいは未評価オペランド（unevaluated operand）というものが使われる。このオペランドは文字通り、評価されない式である。
 </p>
 
 <p>


### PR DESCRIPTION
本文中にunevaluated_operandという語が出てきますが、N3337には一切出てきません。
unevaluated_operandではなく、unevaluated operandが正しいと思われるのでプルリクします。
