### PR TITLE
Fix fontboosting and wrap pre, in other words, make mobile view nicer

### DIFF
--- a/C++11-Syntax-and-Feature.xhtml
+++ b/C++11-Syntax-and-Feature.xhtml
@@ -31,6 +31,13 @@ h1, h2, h3, h4, h5, h6
     font-weight : normal ;
 }
 
+pre
+{
+    white-space: pre-wrap ;
+    word-wrap: break-word ;
+    overflow: auto ;
+}
+
 div#content pre 
 {
     display : block ;
@@ -40,8 +47,6 @@ div#content pre
     border-color: black ;
     padding: 0em 1em 1em 1em  ;
     background-color: #ffffdd ;
-    word-wrap: break-word ;
-    white-space : pre-wrap ;
 
     border-radius: 0.4em ;
 }

--- a/C++11-Syntax-and-Feature.xhtml
+++ b/C++11-Syntax-and-Feature.xhtml
@@ -8,6 +8,8 @@
 C++11: Syntax and Feature
 </title>
 
+<meta name="viewport" content="target-densitydpi=device-dpi, width=device-width, initial-scale=1.0, user-scalable=yes" />
+
 <style type="text/css">
 <![CDATA[
 


### PR DESCRIPTION
一部のwebkit実装には(おそらく)font boostingというバグがあり、font-sizeを無視して大きなサイズが設定されます。
このせいで、本文中のpreに対するworkaround(padding-top:0;)がうまく行っていなかったので、対処。(viewportを設定)

また、モバイル端末では横幅が一番長い要素に合わせて仮想的な画面幅(適切かは微妙)が決まるため、copyrightなどのpreも画面幅で折り返すように設定。
