### PR TITLE
Fix typo (double-byte single-quote)

### DIFF
--- a/C++11-Syntax-and-Feature.xhtml
+++ b/C++11-Syntax-and-Feature.xhtml
@@ -1229,10 +1229,10 @@ auto l2 = 1.0L ;
 </p>
 
 <pre>
-’x’     通常の文字リテラル（ordinary character literal）
-u’x’    char16_t型の文字リテラル
-U’x’    char32_t型の文字リテラル
-L’x’    wchar_t型の文字リテラル。
+'x'     通常の文字リテラル（ordinary character literal）
+u'x'    char16_t型の文字リテラル
+U'x'    char32_t型の文字リテラル
+L'x'    wchar_t型の文字リテラル。
 </pre>
 
 <p>
@@ -1283,7 +1283,7 @@ auto u32_c = U'あ' ;
 アラート文字、ベル文字 alert BEL \a
 バックスラッシュ backslash \ \\
 疑問符 question mark ? \?
-単一引用符 single quote ’ \’
+単一引用符 single quote ' \'
 二重引用符 double quote " \"
 </pre>
 


### PR DESCRIPTION
全角のシングルクォートがあったので半角に訂正。
